### PR TITLE
Update META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -4,6 +4,15 @@
     "perl" : "6.*",
     "build-depends" : [ ],
     "provides" : {
+         "actions" : "lib/actions.pm6",
+        "commander" : "lib/commander.pm6",
+        "commands" : "lib/commands.pm6",
+        "tester" : "lib/tester.pm6",
+        "tmux" : "lib/tmux.pm6",
+        "utils" : "lib/utils.pm6",
+        "waiter" : "lib/waiter.pm6",
+        "commander::godot" : "lib/commander/godot.pm6",
+        "commander::shellish" : "lib/commander/shellish.pm6"
     },
     "tags" : [
         ],


### PR DESCRIPTION
fix install error.

```
zef install https://github.com/bduggan/tmeta.git                                 
===> Searching for missing dependencies: Log::Async
===> Testing: Log::Async:ver<0.0.7>
===> Testing [OK] for Log::Async:ver<0.0.7>
===> Testing: tmeta:ver<0.0.1>
[tmeta] # Failed test 'commander module can be use-d ok'
[tmeta] # at t/01-basic.t line 8
[tmeta] # ===SORRY!=== Error while compiling /Users/ohmycloud/Downloads/tmeta-master/lib/commander.pm6 (commander)
[tmeta] # Could not find commander::shellish in:
[tmeta] #     file#/Users/ohmycloud/Downloads/tmeta-master
[tmeta] #     file#/Users/ohmycloud/.zef/store/p6-log-async.git/41a032c3cb1e50a3f012a5baf993f9ab8fb987cf
[tmeta] #     inst#/Users/ohmycloud/.raku
[tmeta] #     inst#/Users/ohmycloud/opt/rakudo/share/perl6/site
[tmeta] #     inst#/Users/ohmycloud/opt/rakudo/share/perl6/vendor
[tmeta] #     inst#/Users/ohmycloud/opt/rakudo/share/perl6/core
[tmeta] #     ap#
[tmeta] #     nqp#
[tmeta] #     perl5#
[tmeta] # at /Users/ohmycloud/Downloads/tmeta-master/lib/commander.pm6 (commander):3
...
```